### PR TITLE
Get updates from solsticedhiver

### DIFF
--- a/app.yaml
+++ b/app.yaml
@@ -5,9 +5,6 @@ runtime: python27
 api_version: 1
 threadsafe: yes
 
-inbound_services:
-- warmup
-
 instance_class: F1
 automatic_scaling:
   min_idle_instances: 1
@@ -26,10 +23,6 @@ handlers:
 
 - url: /static
   static_dir: static
-  secure: optional
-
-- url: /_ah/warmup
-  script: mirror.app
   secure: optional
 
 - url: /.*

--- a/main.html
+++ b/main.html
@@ -19,7 +19,6 @@
 <div id="form_wrapper">
   <form action="" method="GET" accept-charset="utf-8">
   <div id="input_wrapper">
-    <span id="http_prefix">http://</span>
     <input type="text" name="url" placeholder="type url here..." id="url_entry" autofocus><input id="go_button" type="submit" value="Go">
   </div>
   </form>

--- a/mirror.py
+++ b/mirror.py
@@ -171,10 +171,12 @@ class HomeHandler(BaseHandler):
     # Handle the input form to redirect the user to a relative url
     form_url = self.request.get("url")
     if form_url:
-      # Accept URLs that still have a leading 'http://'
+      # Accept URLs that still have a leading 'http(s)://'
       inputted_url = urllib.unquote(form_url)
       if inputted_url.startswith('http'):
-        inputted_url = inputted_url.lstrip('http://').lstrip('https://')
+        inputted_url = inputted_url.replace('://', '_', 1)
+      else:
+        inputted_url = 'http_'+inputted_url
       return self.redirect("/" + inputted_url)
 
     # Do this dictionary construction here, to decouple presentation from
@@ -202,7 +204,11 @@ class MirrorHandler(BaseHandler):
     logging.debug('Base_url = "%s", url = "%s"', base_url, self.request.url)
 
     translated_address = self.get_relative_url()[1:]  # remove leading /
-    mirrored_url = HTTP_PREFIX + translated_address
+    try:
+      scheme, url = translated_address.split('_', 1)
+      mirrored_url = '%s://%s' % (scheme, url)
+    except ValueError:
+      mirrored_url = 'http://%s' % translated_address
 
     # Use sha256 hash instead of mirrored url for the key name, since key
     # names can only be 500 bytes in length; URLs may be up to 2KB.

--- a/mirror.py
+++ b/mirror.py
@@ -29,7 +29,7 @@ import webapp2
 from google.appengine.ext.webapp import template
 from google.appengine.runtime import apiproxy_errors
 
-import transform_content
+from transform_content import transform_content
 
 ###############################################################################
 
@@ -120,8 +120,7 @@ class MirroredContent(object):
     for content_type in TRANSFORMED_CONTENT_TYPES:
       # startswith() because there could be a 'charset=UTF-8' in the header.
       if page_content_type.startswith(content_type):
-        content = transform_content.TransformContent(base_url, mirrored_url,
-                                                     content)
+        content = transform_content(base_url, mirrored_url, content)
         break
 
     new_content = MirroredContent(

--- a/mirror.py
+++ b/mirror.py
@@ -143,10 +143,6 @@ class MirroredContent(object):
 
 ###############################################################################
 
-class WarmupHandler(webapp2.RequestHandler):
-  def get(self):
-    pass
-
 
 class BaseHandler(webapp2.RequestHandler):
   def get_relative_url(self):
@@ -238,7 +234,5 @@ class MirrorHandler(BaseHandler):
 
 app = webapp2.WSGIApplication([
   (r"/", HomeHandler),
-  (r"/main", HomeHandler),
-  (r"/_ah/warmup", WarmupHandler),
   (r"/([^/]+).*", MirrorHandler),
 ], debug=DEBUG)

--- a/mirror.py
+++ b/mirror.py
@@ -174,8 +174,8 @@ class HomeHandler(BaseHandler):
     if form_url:
       # Accept URLs that still have a leading 'http://'
       inputted_url = urllib.unquote(form_url)
-      if inputted_url.startswith(HTTP_PREFIX):
-        inputted_url = inputted_url[len(HTTP_PREFIX):]
+      if inputted_url.startswith('http'):
+        inputted_url = inputted_url.lstrip('http://').lstrip('https://')
       return self.redirect("/" + inputted_url)
 
     # Do this dictionary construction here, to decouple presentation from

--- a/mirror.py
+++ b/mirror.py
@@ -200,10 +200,10 @@ class MirrorHandler(BaseHandler):
     logging.debug('Base_url = "%s", url = "%s"', base_url, self.request.url)
 
     translated_address = self.get_relative_url()[1:]  # remove leading /
-    try:
+    if translated_address.startswith('http'):
       scheme, url = translated_address.split('_', 1)
       mirrored_url = '%s://%s' % (scheme, url)
-    except ValueError:
+    else:
       mirrored_url = 'http://%s' % translated_address
 
     # Use sha256 hash instead of mirrored url for the key name, since key

--- a/transform_content.py
+++ b/transform_content.py
@@ -37,7 +37,7 @@ SAME_DIR_URL_REGEX = r"(?!(/)|(http(s?)://)|(url\())(?P<url>[^\"'> \t\)]+)"
 ROOT_DIR_URL_REGEX = r"(?!//(?!>))/(?P<url>)(?=[ \t\n]*[\"'\)>/])"
 
 # Start of a tag using 'src' or 'href'
-TAG_START = r"(?i)\b(?P<tag>src|href|action|url|background)(?P<equals>[\t ]*=[\t ]*)(?P<quote>[\"']?)"
+TAG_START = r"(?i)\b(?P<tag>src|href|action|url|background|srcset)(?P<equals>[\t ]*=[\t ]*)(?P<quote>[\"']?)"
 
 # Start of a CSS import
 CSS_IMPORT_START = r"(?i)@import(?P<spacing>[\t ]+)(?P<quote>[\"']?)"


### PR DESCRIPTION
https://github.com/bslatkin/mirrorrr/pull/16#issue-132577342

Name:
> Allow to specify a url scheme

Comment:
> I resurected from the dead this project, and made a few fixes and improvment.
The principal begin to be able to specify a url scheme (http or htpps) before the mirrored url. Example
/https_slashodot.org/
Another one is to be able to use a site that specifies a base tag in the html.
So if you care, merge this PR. Or not :-)